### PR TITLE
Trailing slash should catch directories

### DIFF
--- a/pathspec/gitignore.py
+++ b/pathspec/gitignore.py
@@ -100,7 +100,7 @@ class GitIgnorePattern(RegexPattern):
 					elif i == end:
 						# A normalized pattern ending with double-asterisks ('**')
 						# will match any trailing path segments.
-						regex.append('/.+')
+						regex.append('/.*')
 					else:
 						# A pattern with inner double-asterisks ('**') will match
 						# multiple (or zero) inner path segments.


### PR DESCRIPTION
Found an issue where if you provide a .gitignore line with a trailing slash ('foo/'), it will match files inside but not the directory itself. The .gitignore spec specifies that the directory should be matched as well. This commit changes the end of spec regex to \* to fix this issue.
