### PR TITLE
Test on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: python
+cache: pip
+
+# Supported CPython versions:
+# https://en.wikipedia.org/wiki/CPython#Version_history
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.7
+      dist: xenial
+    - python: 3.6
+    - python: 3.5
+    - python: 3.4
+    - python: 2.7
+
+install:
+ - pip install -U pip
+ - pip install -U tox-travis
+
+script:
+ - tox


### PR DESCRIPTION
To ensure quality, it's a good idea to add a CI server. These can run all the tests for each commit, and are especially useful to show whether tests pass or fail for PRs.

Travis CI is popular and free for open-source projects.

It uses a `.travis.yml` file for config, which says which Python versions to test, what to install, and what to test.

Here's what an example build looks like:
https://travis-ci.org/hugovk/python-path-specification/builds/459083149

Please enable this repo at https://travis-ci.org/cpburnz/python-path-specification