### PR TITLE
Switch the build system to flit_core

### DIFF
--- a/README-dist.rst
+++ b/README-dist.rst
@@ -137,7 +137,6 @@ Installation
 required:
 
 - `build`_ (>=0.6.0)
-- `setuptools`_ (>=40.8.0)
 
 *pathspec* can then be built and installed with::
 
@@ -146,7 +145,6 @@ required:
 
 .. _`PyPI`: http://pypi.python.org/pypi/pathspec
 .. _`build`: https://pypi.org/project/build/
-.. _`setuptools`: https://pypi.org/project/setuptools/
 
 
 Documentation

--- a/README.rst
+++ b/README.rst
@@ -137,7 +137,6 @@ Installation
 required:
 
 - `build`_ (>=0.6.0)
-- `setuptools`_ (>=40.8.0)
 
 *pathspec* can then be built and installed with::
 
@@ -146,7 +145,6 @@ required:
 
 .. _`PyPI`: http://pypi.python.org/pypi/pathspec
 .. _`build`: https://pypi.org/project/build/
-.. _`setuptools`: https://pypi.org/project/setuptools/
 
 
 Documentation

--- a/prebuild.py
+++ b/prebuild.py
@@ -50,16 +50,16 @@ def generate_setup_cfg() -> None:
 		'long_description_content_type': "text/x-rst",
 		'name': config['project']['name'],
 		'url': config['project']['urls']['Source Code'],
-		'version': f"attr: {config['tool']['setuptools']['dynamic']['version']['attr']}",
+		'version': "attr: pathspec._meta.__version__",
 	}
 	output['options'] = {
 		'packages': "find:",
 		'python_requires': config['project']['requires-python'],
-		'setup_requires': ", ".join(config['build-system']['requires']),
+		'setup_requires': "setuptools>=40.8.0",
 		'test_suite': "tests",
 	}
 	output['options.packages.find'] = {
-		'include': ", ".join(config['tool']['setuptools']['packages']['find']['include'])
+		'include': "pathspec, pathspec.*",
 	}
 
 	with open("setup.cfg", 'w', encoding='utf8') as fh:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-build-backend = "setuptools.build_meta"
-requires = ["setuptools>=40.8.0"]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core >=3.2,<4"]
 
 [project]
 authors = [
@@ -34,9 +34,3 @@ requires-python = ">=3.7"
 "Source Code" = "https://github.com/cpburnz/python-pathspec"
 "Documentation" = "https://python-path-specification.readthedocs.io/en/latest/index.html"
 "Issue Tracker" = "https://github.com/cpburnz/python-pathspec/issues"
-
-[tool.setuptools.dynamic]
-version = {attr = "pathspec._meta.__version__"}
-
-[tool.setuptools.packages.find]
-include = ["pathspec", "pathspec.*"]


### PR DESCRIPTION
This is the absolutely minimal change. Since the project was using PEP 621 metadata already, practically no changes were required there. There are two main differences though:

1. Package is always taken as `pathspec`.
2. Version is always taken from `pathspec/__init__.py`.

I've inlined the setuptools-specific values in `prebuild.py` to keep it generating the same file.

One possible optimization is to move version directly into `pathspec/__init__.py`. When it's inline in the file, flit_core reads it via parsing the file's AST. When it's imported indirectly like it is now, it has to actually import the module — but that's not a big deal.