### PR TITLE
Fix partially unknown `PathLike` type

### DIFF
--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -164,13 +164,13 @@ class PathSpec(object):
 
 	def match_file(
 		self,
-		file: Union[str, PathLike],
+		file: Union[str, PathLike[str]],
 		separators: Optional[Collection[str]] = None,
 	) -> bool:
 		"""
 		Matches the file to this path-spec.
 
-		*file* (:class:`str` or :class:`os.PathLike`) is the file path to be
+		*file* (:class:`str` or :class:`os.PathLike[str]`) is the file path to be
 		matched against :attr:`self.patterns <PathSpec.patterns>`.
 
 		*separators* (:class:`~collections.abc.Collection` of :class:`str`)
@@ -184,14 +184,14 @@ class PathSpec(object):
 
 	def match_files(
 		self,
-		files: Iterable[Union[str, PathLike]],
+		files: Iterable[Union[str, PathLike[str]]],
 		separators: Optional[Collection[str]] = None,
-	) -> Iterator[Union[str, PathLike]]:
+	) -> Iterator[Union[str, PathLike[str]]]:
 		"""
 		Matches the files to this path-spec.
 
 		*files* (:class:`~collections.abc.Iterable` of :class:`str` or
-		:class:`os.PathLike`) contains the file paths to be matched against
+		:class:`os.PathLike[str]`) contains the file paths to be matched against
 		:attr:`self.patterns <PathSpec.patterns>`.
 
 		*separators* (:class:`~collections.abc.Collection` of :class:`str`;
@@ -200,7 +200,7 @@ class PathSpec(object):
 		information.
 
 		Returns the matched files (:class:`~collections.abc.Iterator` of
-		:class:`str` or :class:`os.PathLike`).
+		:class:`str` or :class:`os.PathLike[str]`).
 		"""
 		if not _is_iterable(files):
 			raise TypeError(f"files:{files!r} is not an iterable.")
@@ -213,7 +213,7 @@ class PathSpec(object):
 
 	def match_tree_entries(
 		self,
-		root: Union[str, PathLike],
+		root: Union[str, PathLike[str]],
 		on_error: Optional[Callable] = None,
 		follow_links: Optional[bool] = None,
 	) -> Iterator[TreeEntry]:
@@ -221,7 +221,7 @@ class PathSpec(object):
 		Walks the specified root path for all files and matches them to this
 		path-spec.
 
-		*root* (:class:`str` or :class:`os.PathLike`) is the root directory
+		*root* (:class:`str` or :class:`os.PathLike[str]`) is the root directory
 		to search.
 
 		*on_error* (:class:`~collections.abc.Callable` or :data:`None`)
@@ -240,7 +240,7 @@ class PathSpec(object):
 
 	def match_tree_files(
 		self,
-		root: Union[str, PathLike],
+		root: Union[str, PathLike[str]],
 		on_error: Optional[Callable] = None,
 		follow_links: Optional[bool] = None,
 	) -> Iterator[str]:
@@ -248,7 +248,7 @@ class PathSpec(object):
 		Walks the specified root path for all files and matches them to this
 		path-spec.
 
-		*root* (:class:`str` or :class:`os.PathLike`) is the root directory
+		*root* (:class:`str` or :class:`os.PathLike[str]`) is the root directory
 		to search for files.
 
 		*on_error* (:class:`~collections.abc.Callable` or :data:`None`)

--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -3,6 +3,7 @@ This module provides an object oriented interface for pattern matching
 of files.
 """
 
+import sys
 from collections.abc import (
 	Collection as CollectionType)
 from itertools import (
@@ -29,6 +30,11 @@ from .util import (
 	_is_iterable,
 	match_file,
 	normalize_file)
+
+if sys.version_info >= (3,9):
+	StrPath = Union[str, PathLike[str]]
+else:
+	StrPath = Union[str, PathLike]
 
 Self = TypeVar("Self", bound="PathSpec")
 """
@@ -164,7 +170,7 @@ class PathSpec(object):
 
 	def match_file(
 		self,
-		file: Union[str, PathLike[str]],
+		file: StrPath,
 		separators: Optional[Collection[str]] = None,
 	) -> bool:
 		"""
@@ -184,9 +190,9 @@ class PathSpec(object):
 
 	def match_files(
 		self,
-		files: Iterable[Union[str, PathLike[str]]],
+		files: Iterable[StrPath],
 		separators: Optional[Collection[str]] = None,
-	) -> Iterator[Union[str, PathLike[str]]]:
+	) -> Iterator[StrPath]:
 		"""
 		Matches the files to this path-spec.
 
@@ -213,7 +219,7 @@ class PathSpec(object):
 
 	def match_tree_entries(
 		self,
-		root: Union[str, PathLike[str]],
+		root: StrPath,
 		on_error: Optional[Callable] = None,
 		follow_links: Optional[bool] = None,
 	) -> Iterator[TreeEntry]:
@@ -240,7 +246,7 @@ class PathSpec(object):
 
 	def match_tree_files(
 		self,
-		root: Union[str, PathLike[str]],
+		root: StrPath,
 		on_error: Optional[Callable] = None,
 		follow_links: Optional[bool] = None,
 	) -> Iterator[str]:

--- a/pathspec/util.py
+++ b/pathspec/util.py
@@ -7,6 +7,7 @@ import os.path
 import pathlib
 import posixpath
 import stat
+import sys
 import warnings
 from collections.abc import (
 	Collection as CollectionType,
@@ -29,6 +30,11 @@ from typing import (
 
 from .pattern import (
 	Pattern)
+
+if sys.version_info >= (3,9):
+	StrPath = Union[str, PathLike[str]]
+else:
+	StrPath = Union[str, PathLike]
 
 NORMALIZE_PATH_SEPS = [
 	__sep
@@ -141,7 +147,7 @@ def _is_iterable(value: Any) -> bool:
 
 
 def iter_tree_entries(
-	root: Union[str, PathLike[str]],
+	root: StrPath,
 	on_error: Optional[Callable] = None,
 	follow_links: Optional[bool] = None,
 ) -> Iterator['TreeEntry']:
@@ -257,7 +263,7 @@ def _iter_tree_entries_next(
 
 
 def iter_tree_files(
-	root: Union[str, PathLike[str]],
+	root: StrPath,
 	on_error: Optional[Callable] = None,
 	follow_links: Optional[bool] = None,
 ) -> Iterator[str]:
@@ -365,7 +371,7 @@ def match_files(
 
 
 def normalize_file(
-	file: Union[str, PathLike[str]],
+	file: StrPath,
 	separators: Optional[Collection[str]] = None,
 ) -> str:
 	"""
@@ -405,9 +411,9 @@ def normalize_file(
 
 
 def normalize_files(
-	files: Iterable[Union[str, PathLike[str]]],
+	files: Iterable[StrPath],
 	separators: Optional[Collection[str]] = None,
-) -> Dict[str, List[Union[str, PathLike[str]]]]:
+) -> Dict[str, List[StrPath]]:
 	"""
 	DEPRECATED: This function is no longer used. Use the :func:`.normalize_file`
 	function with a loop for better results.

--- a/pathspec/util.py
+++ b/pathspec/util.py
@@ -141,14 +141,14 @@ def _is_iterable(value: Any) -> bool:
 
 
 def iter_tree_entries(
-	root: Union[str, PathLike],
+	root: Union[str, PathLike[str]],
 	on_error: Optional[Callable] = None,
 	follow_links: Optional[bool] = None,
 ) -> Iterator['TreeEntry']:
 	"""
 	Walks the specified directory for all files and directories.
 
-	*root* (:class:`str` or :class:`os.PathLike`) is the root directory to
+	*root* (:class:`str` or :class:`os.PathLike[str]`) is the root directory to
 	search.
 
 	*on_error* (:class:`~collections.abc.Callable` or :data:`None`)
@@ -257,14 +257,14 @@ def _iter_tree_entries_next(
 
 
 def iter_tree_files(
-	root: Union[str, PathLike],
+	root: Union[str, PathLike[str]],
 	on_error: Optional[Callable] = None,
 	follow_links: Optional[bool] = None,
 ) -> Iterator[str]:
 	"""
 	Walks the specified directory for all files.
 
-	*root* (:class:`str` or :class:`os.PathLike`) is the root directory to
+	*root* (:class:`str` or :class:`os.PathLike[str]`) is the root directory to
 	search for files.
 
 	*on_error* (:class:`~collections.abc.Callable` or :data:`None`)
@@ -365,14 +365,14 @@ def match_files(
 
 
 def normalize_file(
-	file: Union[str, PathLike],
+	file: Union[str, PathLike[str]],
 	separators: Optional[Collection[str]] = None,
 ) -> str:
 	"""
 	Normalizes the file path to use the POSIX path separator (i.e.,
 	:data:`'/'`), and make the paths relative (remove leading :data:`'/'`).
 
-	*file* (:class:`str` or :class:`os.PathLike`) is the file path.
+	*file* (:class:`str` or :class:`os.PathLike[str]`) is the file path.
 
 	*separators* (:class:`~collections.abc.Collection` of :class:`str`; or
 	:data:`None`) optionally contains the path separators to normalize.
@@ -405,9 +405,9 @@ def normalize_file(
 
 
 def normalize_files(
-	files: Iterable[Union[str, PathLike]],
+	files: Iterable[Union[str, PathLike[str]]],
 	separators: Optional[Collection[str]] = None,
-) -> Dict[str, List[Union[str, PathLike]]]:
+) -> Dict[str, List[Union[str, PathLike[str]]]]:
 	"""
 	DEPRECATED: This function is no longer used. Use the :func:`.normalize_file`
 	function with a loop for better results.
@@ -415,7 +415,7 @@ def normalize_files(
 	Normalizes the file paths to use the POSIX path separator.
 
 	*files* (:class:`~collections.abc.Iterable` of :class:`str` or
-	:class:`os.PathLike`) contains the file paths to be normalized.
+	:class:`os.PathLike[str]`) contains the file paths to be normalized.
 
 	*separators* (:class:`~collections.abc.Collection` of :class:`str`; or
 	:data:`None`) optionally contains the path separators to normalize.
@@ -423,7 +423,7 @@ def normalize_files(
 
 	Returns a :class:`dict` mapping each normalized file path (:class:`str`)
 	to the original file paths (:class:`list` of :class:`str` or
-	:class:`os.PathLike`).
+	:class:`os.PathLike[str]`).
 	"""
 	warnings.warn((
 		"util.normalize_files() is deprecated. Use util.normalize_file() "


### PR DESCRIPTION
As title says. `PathLike` was missing a type argument.

The name `StrPath` is taken after typeshed's own `StrPath` alias: https://github.com/python/typeshed/blob/main/stdlib/_typeshed/__init__.pyi#L134