### PR TITLE
Add edge case: patterns that end with an escaped space

### DIFF
--- a/pathspec/patterns/gitwildmatch.py
+++ b/pathspec/patterns/gitwildmatch.py
@@ -68,7 +68,14 @@ class GitWildMatchPattern(RegexPattern):
 			raise TypeError(f"pattern:{pattern!r} is not a unicode or byte string.")
 
 		original_pattern = pattern
-		pattern = pattern.strip()
+
+		if pattern.endswith('\\ '):
+			# EDGE CASE: Spaces can be escaped with backslash.
+			# If a pattern that ends with backslash followed by a space,
+			# only strip from left.
+			pattern = pattern.lstrip()
+		else:
+			pattern = pattern.strip()
 
 		if pattern.startswith('#'):
 			# A pattern starting with a hash ('#') serves as a comment

--- a/tests/test_pathspec.py
+++ b/tests/test_pathspec.py
@@ -15,6 +15,7 @@ from pathspec import (
 	PathSpec)
 from pathspec.util import (
 	iter_tree_entries)
+from pathspec.patterns.gitwildmatch import GitWildMatchPatternError
 from tests.util import (
 	make_dirs,
 	make_files,
@@ -118,6 +119,32 @@ class PathSpecTest(unittest.TestCase):
 			'./src/test2/b.txt',
 			'./src/test2/c/c.txt',
 		})
+
+	def test_01_empty_path(self):
+		"""
+		Tests that patterns that end with an escaped space will be treated properly.
+		"""
+		spec = PathSpec.from_lines('gitwildmatch', [
+			'\\ ',
+			'abc\\ '
+		])
+		test_files = [
+			' ',
+			'  ',
+			'abc ',
+			'somefile',
+		]
+		results = list(filter(spec.match_file, test_files))
+		self.assertEqual(results, [
+			' ',
+			'abc '
+		])
+
+		# An escape with double spaces is invalid.
+		# Disallow it. Better to be safe than sorry.
+		self.assertRaises(GitWildMatchPatternError, lambda: PathSpec.from_lines('gitwildmatch', [
+			'\\  '
+		]))
 
 	def test_01_match_files(self):
 		"""


### PR DESCRIPTION
With gitignore, it is possible that the pattern may end with an escaped space, or it may simply consist of an escaped space.

Examples:
- `\ `
- `abc\ `
- `x/yz\ `

This PR handles this edge case.