### PR TITLE
Add support for Python 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,16 +16,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11.0-rc - 3.11",
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12",
                   "pypy-3.7", "pypy-3.8", "pypy-3.9"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python }}
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          allow-prereleases: true
 
       - name: Install tox
         run: python -m pip install tox

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu, macos, windows]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12",
-                  "pypy-3.7", "pypy-3.8", "pypy-3.9"]
+        python: ["3.8", "3.9", "3.10", "3.11", "3.12",
+                 "pypy-3.8", "pypy-3.9"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
 	"Operating System :: OS Independent",
 	"Programming Language :: Python",
 	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.7",
 	"Programming Language :: Python :: 3.8",
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
@@ -29,7 +28,7 @@ dynamic = ["version"]
 license = {text = "MPL 2.0"}
 name = "pathspec"
 readme = "README-dist.rst"
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 
 [project.urls]
 "Source Code" = "https://github.com/cpburnz/python-pathspec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ classifiers = [
 	"Programming Language :: Python :: 3.9",
 	"Programming Language :: Python :: 3.10",
 	"Programming Language :: Python :: 3.11",
+	"Programming Language :: Python :: 3.12",
 	"Programming Language :: Python :: Implementation :: CPython",
 	"Programming Language :: Python :: Implementation :: PyPy",
 	"Topic :: Software Development :: Libraries :: Python Modules",

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ classifiers =
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
 	Programming Language :: Python :: 3.11
+	Programming Language :: Python :: 3.12
 	Programming Language :: Python :: Implementation :: CPython
 	Programming Language :: Python :: Implementation :: PyPy
 	Topic :: Software Development :: Libraries :: Python Modules

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,6 @@ classifiers =
 	Operating System :: OS Independent
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Programming Language :: Python :: 3.10
@@ -28,7 +27,7 @@ version = attr: pathspec._meta.__version__
 
 [options]
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.8
 setup_requires = setuptools>=40.8.0
 test_suite = tests
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, py311, py312, pypy3
+envlist = py38, py39, py310, py311, py312, pypy3
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
The [Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/
