### PR TITLE
Fix KeyError in detailed_match_files for unmatched negation patterns

### DIFF
--- a/pathspec/util.py
+++ b/pathspec/util.py
@@ -156,7 +156,8 @@ def detailed_match_files(
 			else:
 				# Remove files.
 				for file in result_files:
-					del return_files[file]
+					if file in return_files:
+						del return_files[file]
 
 	return return_files
 


### PR DESCRIPTION
`detailed_match_files()` raises `KeyError` when a negation pattern (`include=False`) matches a file that wasn't previously added by an inclusion pattern.

For example:

```python
from pathspec import PathSpec

# Pattern list where negation is broader than inclusion
spec = PathSpec.from_lines('gitwildmatch', [
    '*.txt',
    '!*.log',
])

# detailed_match_files processes patterns in order:
# 1. '*.txt' (include=True) → adds .txt files to result
# 2. '!*.log' (include=False) → tries to remove .log files → KeyError
spec.match_files(['test.txt', 'test.log'], details=True)
```

The `!*.log` negation pattern matches `test.log`, but that file was never added to the result set by a prior inclusion pattern. The `del return_files[file]` on line 160 of `util.py` raises `KeyError`.

The fix adds a membership check before deletion — if a file isn't in the result set, the negation is simply a no-op, which is consistent with how gitignore processes negation (it can only un-ignore files that were previously ignored).
