### PR TITLE
Fix escape() not escaping backslash characters

### DIFF
--- a/pathspec/patterns/gitignore/base.py
+++ b/pathspec/patterns/gitignore/base.py
@@ -47,7 +47,7 @@ class _GitIgnoreBasePattern(RegexPattern):
 			raise TypeError(f"s:{s!r} is not a unicode or byte string.")
 
 		# Reference: https://git-scm.com/docs/gitignore#_pattern_format
-		out_string = ''.join((f"\\{x}" if x in '[]!*#?' else x) for x in string)
+		out_string = ''.join((f"\\{x}" if x in '\\[]!*#?' else x) for x in string)
 
 		if return_type is bytes:
 			return out_string.encode(_BYTES_ENCODING)


### PR DESCRIPTION
The `escape()` method is meant to escape special characters in a filename so it can be safely used as a gitignore pattern. Currently it escapes `[]!*#?` but misses backslash (`\`), which is the escape character in gitignore patterns.

This means `escape()` doesn't produce a round-trippable result for filenames containing backslashes:

```python
from pathspec import PathSpec
from pathspec.patterns.gitignore.base import _GitIgnoreBasePattern

filename = "foo\\bar"

escaped = _GitIgnoreBasePattern.escape(filename)
# Returns 'foo\\bar' — unchanged, backslash NOT escaped

spec = PathSpec.from_lines('gitwildmatch', [escaped])
spec.match_file(filename)
# Returns False — the pattern doesn't match the original filename!
# The parser consumed the backslash as an escape for 'b',
# so the pattern actually matches 'foobar' instead of 'foo\bar'
```

The fix adds `\\` to the set of escaped characters, so `escape('foo\\bar')` correctly produces `'foo\\\\bar'`, which the parser then interprets as a literal backslash.
