### PR TITLE
Proposal: Drop the traceback from the module-level backend error objects.

### DIFF
--- a/pathspec/_backends/hyperscan/base.py
+++ b/pathspec/_backends/hyperscan/base.py
@@ -15,7 +15,7 @@ try:
 	hyperscan_error = None
 except ModuleNotFoundError as e:
 	hyperscan = None
-	hyperscan_error = e
+	hyperscan_error = e.with_traceback(None)
 
 hyperscan_error: Optional[ModuleNotFoundError]
 """

--- a/pathspec/_backends/re2/_base.py
+++ b/pathspec/_backends/re2/_base.py
@@ -18,7 +18,7 @@ try:
 	re2_error = None
 except ModuleNotFoundError as e:
 	re2 = None
-	re2_error = e
+	re2_error = e.with_traceback(None)
 	RE2_OPTIONS = None
 else:
 	# Both the `google-re2` and `pyre2` libraries use the `re2` namespace.
@@ -28,7 +28,7 @@ else:
 		RE2_OPTIONS.log_errors = False
 		RE2_OPTIONS.never_capture = True
 	except Exception as e:
-		re2_error = e
+		re2_error = e.with_traceback(None)
 		RE2_OPTIONS = None
 
 RE2_OPTIONS: re2.Options


### PR DESCRIPTION
Why? These are module-level objects that will live forever. Normally this is fine. But if we lazily import `pathspec` in somewhere deep in the Python program (or with the upcoming PEP 810 explicit lazy import in Python 3.15), it will hold the traceback, thus the locals of each frame, in memory forever.

We ran into such case where we might hold GBs of memory because of this edge case.

As far as I can tell, we don't really need the traceback on the exception object here.

What do you think? I can totally understand this seems to be out of the blue optimization for super rare edge cases.

Thanks for your consideration in advance!