### PR TITLE
Fix PathSpec.from_lines triggering reportUnknownMemberType under strict pyright

### DIFF
--- a/pathspec/pathspec.py
+++ b/pathspec/pathspec.py
@@ -246,7 +246,7 @@ class PathSpec(Generic[TPattern]):
 	@overload
 	@classmethod
 	def from_lines(
-		cls: type[PathSpec],
+		cls: type[PathSpec[TPattern]],
 		pattern_factory: Callable[[AnyStr], TPattern],
 		lines: Iterable[AnyStr],
 		*,


### PR DESCRIPTION
## Summary

Fixes #113.

The generic overload added in 1.1.0 declares \`cls: type[PathSpec]\`, leaving the method-local TypeVar \`TPattern\` unanchored to the class. Pyright then renders the unsolved TypeVar as \`Unknown\` in the displayed overload set (\`(AnyStr) -> Unknown\`, \`Sequence[Unknown]\`, \`PathSpec[Unknown]\`), tripping \`reportUnknownMemberType\` on every reference to \`from_lines\` — even when the call cleanly matches a non-generic overload.

Anchoring the TypeVar via \`cls: type[PathSpec[TPattern]]\` makes the binding class-scoped, which eliminates the spurious diagnostic without changing runtime behavior or other overloads.

## Repro (before)

\`\`\`python
import pathspec
patterns: list[str] = []
spec = pathspec.PathSpec.from_lines(pattern_factory="gitignore", lines=patterns)
\`\`\`

\`\`\`
uv run --with pathspec==1.1.0 --with pyright==1.1.408 pyright --strict repro.py
\`\`\`

\`\`\`
error: Type of "from_lines" is partially unknown
  ... PathSpec[Unknown] ... (reportUnknownMemberType)
\`\`\`

## After

\`0 errors, 0 warnings, 0 informations\`

## Test plan

- [x] \`python -m unittest discover -s tests -t .\` — 195 passed (276 skipped, same as baseline)
- [x] Pyright strict mode on the repro now reports 0 errors
- [x] All three overloads still resolve correctly for: \`pattern_factory="gitignore"\`, custom \`Callable[[str], TPattern]\`, and non-literal \`str\`