### PR TITLE
fix: ignore invalid gitignore bracket ranges

### DIFF
--- a/pathspec/patterns/gitignore/base.py
+++ b/pathspec/patterns/gitignore/base.py
@@ -161,6 +161,15 @@ class _GitIgnoreBasePattern(RegexPattern):
 					# as literal slashes by regex as defined by POSIX.
 					expr += pattern[i:j].replace('\\', '\\\\')
 
+					if range_error == 'raise':
+						try:
+							re.compile(expr)
+						except re.error as e:
+							raise _RangeError((
+								f"Invalid range notation={pattern[i:j]!r} found in "
+								f"pattern={pattern!r}."
+							)) from e
+
 					# Add regex bracket expression to regex result.
 					regex += expr
 

--- a/tests/test_04_gitignore_spec.py
+++ b/tests/test_04_gitignore_spec.py
@@ -944,16 +944,14 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 				self.assertIs(pattern.include, None)
 				self.assertIs(pattern.regex, None)
 
-		# The `re` module fails to compile these.
-		# - NOTE: Technically, these should result in null patterns rather than
-		#   exceptions to fully replicate Git's behavior.
 		for raw_pattern in [
 			'[z-a]',
 			'a[z-a]',
 		]:
 			with self.subTest(f"p={raw_pattern!r}"):
-				with self.assertRaises(re_PatternError):
-					GitIgnoreSpecPattern(raw_pattern)
+				pattern = GitIgnoreSpecPattern(raw_pattern)
+				self.assertIs(pattern.include, None)
+				self.assertIs(pattern.regex, None)
 
 	def test_15_issue_93_c_3_unclosed(self):
 		"""


### PR DESCRIPTION

## Summary

This updates `GitIgnoreSpecPattern` so reversed invalid bracket ranges such as `[z-a]` and `a[z-a]` are treated as null patterns instead of propagating a regex compile error.

This matches the existing invalid-range handling direction for gitignore spec patterns and keeps `GitIgnoreBasicPattern` behavior unchanged.

## What changed

- Validate completed bracket expressions in the `range_error == "raise"` path.
- Convert regex compile failures for invalid bracket ranges into the existing `_RangeError` flow.
- Update the focused Issue #93 regression test so `[z-a]` and `a[z-a]` produce null patterns:
  - `include is None`
  - `regex is None`

## Why

The surrounding test already notes that these patterns should become null patterns to fully replicate Git behavior. This makes reversed invalid ranges consistent with the existing invalid-range cases already covered by the test suite.

## Tests

Ran:

```bash
python -m unittest tests.test_04_gitignore_spec.GitIgnoreSpecPatternTest.test_15_issue_93_c_2_invalid
python -m unittest tests.test_04_gitignore_spec
python -m unittest tests.test_03_gitignore_basic
python -m unittest tests.test_06_gitignore
python -m unittest discover -t . -s tests/
```

Full configured unittest result:

```text
Ran 197 tests in 0.203s
OK (skipped=276)
```

## Compatibility notes

- Scoped to `GitIgnoreSpecPattern`.
- `GitIgnoreBasicPattern` behavior is unchanged.
- Matching, path normalization, backend dispatch, and tree-walk behavior are unchanged.
