### PR TITLE
Escape trailing spaces in GitIgnoreSpecPattern.escape()

### DIFF
--- a/pathspec/patterns/gitignore/base.py
+++ b/pathspec/patterns/gitignore/base.py
@@ -105,6 +105,14 @@ class _GitIgnoreBasePattern(RegexPattern):
 		# Reference: https://git-scm.com/docs/gitignore#_pattern_format
 		out_string = ''.join((f"\\{x}" if x in '\\[]!*#?' else x) for x in string)
 
+		# EDGE CASE: Git strips trailing spaces from a pattern unless they are
+		# escaped with a backslash. Escape them so an escaped filename that ends
+		# with a space still matches that file.
+		stripped = out_string.rstrip(' ')
+		trailing = len(out_string) - len(stripped)
+		if trailing:
+			out_string = stripped + '\\ ' * trailing
+
 		if return_type is bytes:
 			out_bytes = out_string.encode(_BYTES_ENCODING)
 			return out_bytes  # type: ignore[return-value]

--- a/tests/test_02_gitignore_base.py
+++ b/tests/test_02_gitignore_base.py
@@ -20,7 +20,7 @@ class GitIgnoreBasePatternTest(unittest.TestCase):
 		Test escaping binary strings.
 		"""
 		byte_to_escaped = {__b: b'\\' + __b for __b in (
-			__c.encode(_BYTES_ENCODING) for __c in '\\[]!*#?'
+			__c.encode(_BYTES_ENCODING) for __c in '\\[]!*#? '
 		)}
 		for char_ord in range(256):
 			char_byte = chr(char_ord).encode(_BYTES_ENCODING)
@@ -32,7 +32,7 @@ class GitIgnoreBasePatternTest(unittest.TestCase):
 		"""
 		Test escaping unicode strings.
 		"""
-		char_to_escaped = {__c: f"\\{__c}" for __c in '\\[]!*#?'}
+		char_to_escaped = {__c: f"\\{__c}" for __c in '\\[]!*#? '}
 		for char_ord in range(128):
 			char = chr(char_ord)
 			escape_val = _GitIgnoreBasePattern.escape(char)

--- a/tests/test_04_gitignore_spec.py
+++ b/tests/test_04_gitignore_spec.py
@@ -621,6 +621,18 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		result = GitIgnoreSpecPattern.escape(fname)
 		self.assertEqual(result, escaped)
 
+	def test_08_escape_trailing_space(self):
+		"""
+		Test that escaping a filename with a trailing space keeps the space, so
+		the escaped pattern still matches the file. Git strips unescaped trailing
+		spaces from a pattern.
+		"""
+		for fname in ['foo ', 'trailing  ', ' ']:
+			escaped = GitIgnoreSpecPattern.escape(fname)
+			self.assertTrue(escaped.endswith('\\ '), (fname, escaped))
+			pattern = GitIgnoreSpecPattern(escaped)
+			self.assertEqual(set(filter(pattern.match_file, [fname])), {fname}, (fname, escaped))
+
 	def test_09_single_escape_fail(self):
 		"""
 		Test an escape on a line by itself.


### PR DESCRIPTION
`GitIgnoreSpecPattern.escape()` escapes `\ [ ] ! * # ?` but not trailing spaces. Git strips unescaped trailing spaces from a pattern, and the parser in this library already relies on that: `pattern_to_regex` keeps trailing spaces only when the pattern ends with an escaped space (`\ `), otherwise it `rstrip()`s them.

The result is an internal round-trip inconsistency, so nothing about git's own behavior needs to be consulted to see it: an escaped filename that ends with a space no longer matches that file.

```python
from pathspec.patterns import GitWildMatchPattern as P
esc = P.escape("foo ")          # -> "foo " (trailing space not escaped)
GitWildMatchPattern(esc).match_file("foo ")   # -> False
```

`escape(" ")` is the extreme case: a lone space escapes to `" "`, which the parser reduces to an empty (null) pattern that matches nothing.

The fix escapes each trailing space (space only, matching git, which strips trailing spaces but not tabs), so the escaped pattern round-trips. This extends the recent backslash fix in 7b2b708 ("Fix escape() not escaping backslash characters") rather than changing any deliberate behavior; trailing spaces are the same class of character git treats specially in a pattern that `escape()` didn't yet cover.

Two existing char-map tests (`test_01_escape_str` / `_bytes`) asserted that a lone space escapes to itself, which is exactly the round-trip gap, so I updated them to expect an escaped space, and added a round-trip test (`test_08_escape_trailing_space`). Full test suite passes.
