### PR TITLE
Keep trailing globstars from matching their parent directory

### DIFF
--- a/CHANGES_1.in.rst
+++ b/CHANGES_1.in.rst
@@ -16,6 +16,8 @@ New features:
 
 Bug fixes:
 
+- Patterns ending in ``/**`` no longer match their bare parent directory, preserving traversal to re-included children (issue #137, part A).
+
 - `Pull #123`_: Ignore invalid gitignore bracket ranges for `GitIgnoreSpec`.
 - `Pull #128`_: Support POSIX character classes (e.g. `[[:alpha:]]`) in gitignore bracket expressions.
 - `Issue #129`_ / `Pull #132`_: Fix GitIgnoreSpec re-including files under an excluded directory

--- a/pathspec/patterns/gitignore/basic.py
+++ b/pathspec/patterns/gitignore/basic.py
@@ -221,7 +221,7 @@ class GitIgnoreBasicPattern(_GitIgnoreBasePattern):
 		elif pattern_segs is not None:
 			# Build regular expression from pattern.
 			try:
-				regex_parts = cls.__translate_segments(pattern_segs)
+				regex_parts = cls.__translate_segments(is_dir_pattern, pattern_segs)
 			except ValueError as e:
 				raise GitIgnorePatternError((
 					f"Invalid git pattern: {original_pattern!r}"
@@ -245,9 +245,12 @@ class GitIgnoreBasicPattern(_GitIgnoreBasePattern):
 		return (out_regex, include)
 
 	@classmethod
-	def __translate_segments(cls, pattern_segs: list[str]) -> list[str]:
+	def __translate_segments(cls, is_dir_pattern: bool, pattern_segs: list[str]) -> list[str]:
 		"""
 		Translate the pattern segments to regular expressions.
+
+		*is_dir_pattern* (:class:`bool`) is whether the original pattern ends
+		with a slash.
 
 		*pattern_segs* (:class:`list` of :class:`str`) contains the pattern
 		segments.
@@ -276,8 +279,8 @@ class GitIgnoreBasicPattern(_GitIgnoreBasePattern):
 				else:
 					assert i == end, (i, end)
 					# A normalized pattern ending with double-asterisks ('**') will match
-					# any trailing path segments.
-					out_parts.append('/')
+					# nonempty trailing path segments, not the parent directory itself.
+					out_parts.append('/' if is_dir_pattern else '/[^/]')
 
 			else:
 				# Match path segment.

--- a/pathspec/patterns/gitignore/spec.py
+++ b/pathspec/patterns/gitignore/spec.py
@@ -317,11 +317,11 @@ class GitIgnoreSpecPattern(_GitIgnoreBasePattern):
 				else:
 					assert i == end, (i, end)
 					# A normalized pattern ending with double-asterisks ('**') will match
-					# any trailing path segments.
+					# nonempty trailing path segments, not the parent directory itself.
 					if is_dir_pattern:
 						out_parts.append(_DIR_MARK_CG)
 					else:
-						out_parts.append('/')
+						out_parts.append('/[^/]')
 
 			else:
 				# Match path segment.

--- a/tests/test_03_gitignore_basic.py
+++ b/tests/test_03_gitignore_basic.py
@@ -229,11 +229,12 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('spam/**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^spam/')
+		self.assertEqual(regex, '^spam/[^/]')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
 			'spam/bar',
+			'spam/',
 			'foo/spam/bar',
 		]))
 		self.assertEqual(results, {'spam/bar'})
@@ -363,7 +364,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/api/**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^(?:.+/)?api/')
+		self.assertEqual(regex, '^(?:.+/)?api/[^/]')
 
 		equiv_regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/**/api/**/**')
 		self.assertTrue(include)
@@ -843,7 +844,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreBasicPattern('!libfoo/**')
 
-		self.assertEqual(pattern.regex.pattern, '^libfoo/')
+		self.assertEqual(pattern.regex.pattern, '^libfoo/[^/]')
 		self.assertIs(pattern.include, False)
 		self.assertTrue(pattern.match_file('libfoo/__init__.py'))
 

--- a/tests/test_04_gitignore_spec.py
+++ b/tests/test_04_gitignore_spec.py
@@ -228,11 +228,12 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('spam/**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^spam/')
+		self.assertEqual(regex, '^spam/[^/]')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
 			'spam/bar',
+			'spam/',
 			'foo/spam/bar',
 		]))
 		self.assertEqual(results, {'spam/bar'})
@@ -362,7 +363,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/api/**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^(?:.+/)?api/')
+		self.assertEqual(regex, '^(?:.+/)?api/[^/]')
 
 		equiv_regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/**/api/**/**')
 		self.assertTrue(include)
@@ -876,7 +877,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreSpecPattern('!libfoo/**')
 
-		self.assertEqual(pattern.regex.pattern, '^libfoo/')
+		self.assertEqual(pattern.regex.pattern, '^libfoo/[^/]')
 		self.assertIs(pattern.include, False)
 		self.assertTrue(pattern.match_file('libfoo/__init__.py'))
 

--- a/tests/test_06_gitignore.py
+++ b/tests/test_06_gitignore.py
@@ -907,3 +907,11 @@ class GitIgnoreSpecTest(unittest.TestCase):
 					"node_modules/",
 					"node_modules/leaf.txt",
 				}, debug)
+
+	def test_trailing_globstar_does_not_ignore_parent(self):
+		for sub_test in self.parameterize_from_lines(["d/**"]):
+			with sub_test() as spec:
+				self.assertFalse(spec.match_file("d/"))
+				self.assertTrue(spec.match_file("d/file"))
+				self.assertTrue(spec.match_file("d/child/"))
+				self.assertTrue(spec.match_file("d/\nfile"))

--- a/tests/test_06_gitignore.py
+++ b/tests/test_06_gitignore.py
@@ -909,10 +909,10 @@ class GitIgnoreSpecTest(unittest.TestCase):
 				}, debug)
 
 
-	def test_12_issue_132_a(self):
-    """
-    Test that trailing glob-stars do not ignore parent.
-    """
+	def test_12_issue_137_a(self):
+		"""
+		Test that trailing glob-stars do not ignore parent.
+		"""
 		for sub_test in self.parameterize_from_lines(["d/**"]):
 			with sub_test() as spec:
 				self.assertFalse(spec.match_file("d/"))


### PR DESCRIPTION
Addresses part A of #137, reported and reduced by @KaizenShogun. `d/**` currently matches the bare directory query `d/`, so a caller pruning a walk can skip children that a later negation would re-include. Require a nonempty child segment after the trailing globstar's slash. Keep explicit directory patterns such as `d/` unchanged, and cover child names beginning with a newline.

The regression failed on the base. Validation: 213 tests and 591 subtests pass with simple, RE2, and Hyperscan backends on CPython 3.12.14. A real Git repository canary confirms `d/**` plus `!d/canary` permits staging and traversal, while `d/` plus the same negation excludes it. Updated affected regex expectations and added a changelog entry.

This does not address part B of #137. Implemented and locally validated with OpenAI Codex.
