### PR TITLE
Match newlines in gitignore globstar path segments

### DIFF
--- a/CHANGES_1.in.rst
+++ b/CHANGES_1.in.rst
@@ -16,6 +16,8 @@ New features:
 
 Bug fixes:
 
+- Match newline characters in directory names when expanding gitignore globstars, including implicit leading globstars.
+
 - `Pull #123`_: Ignore invalid gitignore bracket ranges for `GitIgnoreSpec`.
 - `Pull #128`_: Support POSIX character classes (e.g. `[[:alpha:]]`) in gitignore bracket expressions.
 - `Issue #129`_ / `Pull #132`_: Fix GitIgnoreSpec re-including files under an excluded directory

--- a/pathspec/patterns/gitignore/basic.py
+++ b/pathspec/patterns/gitignore/basic.py
@@ -98,7 +98,7 @@ class GitIgnoreBasicPattern(_GitIgnoreBasePattern):
 				return (None, '/')
 			else:
 				# The pattern "**" will match every path. Special case this pattern.
-				return (None, '.')
+				return (None, '(?s:.)')
 
 		elif (
 			seg_count == 2
@@ -107,7 +107,7 @@ class GitIgnoreBasicPattern(_GitIgnoreBasePattern):
 		):
 			# The pattern "*" will be normalized to "**/*" and will match every
 			# path. Special case this pattern for efficiency.
-			return (None, '.')
+			return (None, '(?s:.)')
 
 		elif (
 			seg_count == 3
@@ -265,12 +265,12 @@ class GitIgnoreBasicPattern(_GitIgnoreBasePattern):
 					# match any leading path segments.
 					# - NOTICE: '(?:^|/)' benchmarks slower using p15 (sm=0.9382,
 					#   hs=0.9966, re2=0.9337).
-					out_parts.append('^(?:.+/)?')
+					out_parts.append('^(?:(?s:.)+/)?')
 
 				elif i < end:
 					# A pattern with inner double-asterisks ('**') will match multiple (or
 					# zero) inner path segments.
-					out_parts.append('(?:/.+)?')
+					out_parts.append('(?:/(?s:.)+)?')
 					need_slash = True
 
 				else:

--- a/pathspec/patterns/gitignore/spec.py
+++ b/pathspec/patterns/gitignore/spec.py
@@ -39,7 +39,7 @@ _DIR_MARK_OPT = f'(?:{_DIR_MARK_CG}|$)'
 This regular expression matches the optional directory marker and sub-path.
 """
 
-_MATCH_ALL = f'^(?:.+/)?[^/]+{_DIR_MARK_OPT}'
+_MATCH_ALL = f'^(?:(?s:.)+/)?[^/]+{_DIR_MARK_OPT}'
 """
 This regular expression matches every path. It is the expansion of the patterns
 "*" and "**" (i.e., "**/{any name}"), and it has to capture the directory marker
@@ -306,12 +306,12 @@ class GitIgnoreSpecPattern(_GitIgnoreBasePattern):
 				if i == 0:
 					# A normalized pattern beginning with double-asterisks ('**') will
 					# match any leading path segments.
-					out_parts.append('^(?:.+/)?')
+					out_parts.append('^(?:(?s:.)+/)?')
 
 				elif i < end:
 					# A pattern with inner double-asterisks ('**') will match multiple (or
 					# zero) inner path segments.
-					out_parts.append('(?:/.+)?')
+					out_parts.append('(?:/(?s:.)+)?')
 					need_slash = True
 
 				else:

--- a/tests/test_03_gitignore_basic.py
+++ b/tests/test_03_gitignore_basic.py
@@ -99,7 +99,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		# GitIgnoreSpecPattern.
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('/')
 		self.assertTrue(include)
-		self.assertEqual(regex, '.')
+		self.assertEqual(regex, '(?s:.)')
 
 	def test_01_absolute_root_2_double_asterisk(self):
 		"""
@@ -138,7 +138,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('spam')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?spam{_DIR_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?spam{_DIR_OPT}')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -202,7 +202,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('!temp')
 		self.assertIs(include, False)
-		self.assertEqual(regex, f'^(?:.+/)?temp{_DIR_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?temp{_DIR_OPT}')
 
 		# NOTE: The pattern match is backwards because the pattern itself
 		# does not consider the include attribute.
@@ -255,7 +255,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('left/**/right')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^left(?:/.+)?/right{_DIR_OPT}')
+		self.assertEqual(regex, f'^left(?:/(?s:.)+)?/right{_DIR_OPT}')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -278,7 +278,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '.')
+		self.assertEqual(regex, '(?s:.)')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -315,7 +315,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/spam')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?spam{_DIR_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?spam{_DIR_OPT}')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -335,7 +335,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '.')
+		self.assertEqual(regex, '(?s:.)')
 
 		equiv_regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/**')
 		self.assertTrue(include)
@@ -347,7 +347,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/api')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?api{_DIR_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?api{_DIR_OPT}')
 
 		equiv_regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/**/api')
 		self.assertTrue(include)
@@ -355,7 +355,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/api/')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^(?:.+/)?api/')
+		self.assertEqual(regex, '^(?:(?s:.)+/)?api/')
 
 		equiv_regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/**/api/')
 		self.assertTrue(include)
@@ -363,7 +363,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/api/**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^(?:.+/)?api/')
+		self.assertEqual(regex, '^(?:(?s:.)+/)?api/')
 
 		equiv_regex, include = GitIgnoreBasicPattern.pattern_to_regex('**/**/api/**/**')
 		self.assertTrue(include)
@@ -397,7 +397,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('foo-*-bar')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?foo\\-[^/]*\\-bar{_DIR_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?foo\\-[^/]*\\-bar{_DIR_OPT}')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -429,7 +429,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('~temp-*')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?\\~temp\\-[^/]*{_DIR_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?\\~temp\\-[^/]*{_DIR_OPT}')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -460,7 +460,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('*.py')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?[^/]*\\.py{_DIR_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?[^/]*\\.py{_DIR_OPT}')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -492,7 +492,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('dir/')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^(?:.+/)?dir/')
+		self.assertEqual(regex, '^(?:(?s:.)+/)?dir/')
 
 		pattern = GitIgnoreBasicPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -750,7 +750,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreBasicPattern.pattern_to_regex('*')
 		self.assertTrue(include)
-		self.assertEqual(regex, '.')
+		self.assertEqual(regex, '(?s:.)')
 
 	def test_12_asterisk_2_regex_equivalent(self):
 		"""
@@ -865,7 +865,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		# GitIgnoreSpecPattern should not.
 		pattern = GitIgnoreBasicPattern('!libfoo/')
 
-		self.assertEqual(pattern.regex.pattern, '^(?:.+/)?libfoo/')
+		self.assertEqual(pattern.regex.pattern, '^(?:(?s:.)+/)?libfoo/')
 		self.assertIs(pattern.include, False)
 		self.assertTrue(pattern.match_file('libfoo/__init__.py'))
 
@@ -875,7 +875,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreBasicPattern('foo**')
 		self.assertIs(pattern.include, True)
-		self.assertEqual(pattern.regex.pattern, f'^(?:.+/)?foo[^/]*[^/]*{_DIR_OPT}')
+		self.assertEqual(pattern.regex.pattern, f'^(?:(?s:.)+/)?foo[^/]*[^/]*{_DIR_OPT}')
 		self.assertTrue(pattern.match_file('foosrodah'))
 
 	def test_15_issue_93_a_2(self):
@@ -894,7 +894,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreBasicPattern(' foo')
 		self.assertIs(pattern.include, True)
-		self.assertEqual(pattern.regex.pattern, f'^(?:.+/)?\\ foo{_DIR_OPT}')
+		self.assertEqual(pattern.regex.pattern, f'^(?:(?s:.)+/)?\\ foo{_DIR_OPT}')
 		self.assertFalse(pattern.match_file('foo'))
 		self.assertTrue(pattern.match_file(' foo'))
 
@@ -904,7 +904,7 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreBasicPattern('  foo')
 		self.assertIs(pattern.include, True)
-		self.assertEqual(pattern.regex.pattern, f'^(?:.+/)?\\ \\ foo{_DIR_OPT}')
+		self.assertEqual(pattern.regex.pattern, f'^(?:(?s:.)+/)?\\ \\ foo{_DIR_OPT}')
 		self.assertFalse(pattern.match_file('foo'))
 		self.assertFalse(pattern.match_file(' foo'))
 		self.assertTrue(pattern.match_file('  foo'))
@@ -914,12 +914,12 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		Test patterns with valid range notation.
 		"""
 		for raw_pattern, regex in [
-			('[!a-z]', f'^(?:.+/)?[^a-z]{_DIR_OPT}'),
-			('[^a-z]', f'^(?:.+/)?[^a-z]{_DIR_OPT}'),
-			('[a-z]', f'^(?:.+/)?[a-z]{_DIR_OPT}'),
-			('a[!a-z]', f'^(?:.+/)?a[^a-z]{_DIR_OPT}'),
-			('a[^a-z]', f'^(?:.+/)?a[^a-z]{_DIR_OPT}'),
-			('a[a-z]', f'^(?:.+/)?a[a-z]{_DIR_OPT}'),
+			('[!a-z]', f'^(?:(?s:.)+/)?[^a-z]{_DIR_OPT}'),
+			('[^a-z]', f'^(?:(?s:.)+/)?[^a-z]{_DIR_OPT}'),
+			('[a-z]', f'^(?:(?s:.)+/)?[a-z]{_DIR_OPT}'),
+			('a[!a-z]', f'^(?:(?s:.)+/)?a[^a-z]{_DIR_OPT}'),
+			('a[^a-z]', f'^(?:(?s:.)+/)?a[^a-z]{_DIR_OPT}'),
+			('a[a-z]', f'^(?:(?s:.)+/)?a[a-z]{_DIR_OPT}'),
 		]:
 			with self.subTest(f"p={raw_pattern!r}"):
 				pattern = GitIgnoreBasicPattern(raw_pattern)
@@ -932,10 +932,10 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		"""
 		# The basic pattern treats invalid range notation as a literal.
 		for raw_pattern, regex in [
-			('[!]', f'^(?:.+/)?\\[!\\]{_DIR_OPT}'),
-			('[^]', f'^(?:.+/)?\\[\\^\\]{_DIR_OPT}'),
-			('a[!]', f'^(?:.+/)?a\\[!\\]{_DIR_OPT}'),
-			('a[^]', f'^(?:.+/)?a\\[\\^\\]{_DIR_OPT}'),
+			('[!]', f'^(?:(?s:.)+/)?\\[!\\]{_DIR_OPT}'),
+			('[^]', f'^(?:(?s:.)+/)?\\[\\^\\]{_DIR_OPT}'),
+			('a[!]', f'^(?:(?s:.)+/)?a\\[!\\]{_DIR_OPT}'),
+			('a[^]', f'^(?:(?s:.)+/)?a\\[\\^\\]{_DIR_OPT}'),
 		]:
 			with self.subTest(f"p={raw_pattern!r}"):
 				pattern = GitIgnoreBasicPattern(raw_pattern)
@@ -956,19 +956,19 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		Test patterns with unclosed range notation.
 		"""
 		for raw_pattern, regex in [
-			('[!', f'^(?:.+/)?\\[!{_DIR_OPT}'),
-			('[', f'^(?:.+/)?\\[{_DIR_OPT}'),
-			('[-', f'^(?:.+/)?\\[\\-{_DIR_OPT}'),
-			('[^', f'^(?:.+/)?\\[\\^{_DIR_OPT}'),
-			('[a', f'^(?:.+/)?\\[a{_DIR_OPT}'),
-			('[a-', f'^(?:.+/)?\\[a\\-{_DIR_OPT}'),
-			('[a-z', f'^(?:.+/)?\\[a\\-z{_DIR_OPT}'),
-			('a[!', f'^(?:.+/)?a\\[!{_DIR_OPT}'),
-			('a[', f'^(?:.+/)?a\\[{_DIR_OPT}'),
-			('a[-', f'^(?:.+/)?a\\[\\-{_DIR_OPT}'),
-			('a[^', f'^(?:.+/)?a\\[\\^{_DIR_OPT}'),
-			('a[a-', f'^(?:.+/)?a\\[a\\-{_DIR_OPT}'),
-			('a[a-z', f'^(?:.+/)?a\\[a\\-z{_DIR_OPT}'),
+			('[!', f'^(?:(?s:.)+/)?\\[!{_DIR_OPT}'),
+			('[', f'^(?:(?s:.)+/)?\\[{_DIR_OPT}'),
+			('[-', f'^(?:(?s:.)+/)?\\[\\-{_DIR_OPT}'),
+			('[^', f'^(?:(?s:.)+/)?\\[\\^{_DIR_OPT}'),
+			('[a', f'^(?:(?s:.)+/)?\\[a{_DIR_OPT}'),
+			('[a-', f'^(?:(?s:.)+/)?\\[a\\-{_DIR_OPT}'),
+			('[a-z', f'^(?:(?s:.)+/)?\\[a\\-z{_DIR_OPT}'),
+			('a[!', f'^(?:(?s:.)+/)?a\\[!{_DIR_OPT}'),
+			('a[', f'^(?:(?s:.)+/)?a\\[{_DIR_OPT}'),
+			('a[-', f'^(?:(?s:.)+/)?a\\[\\-{_DIR_OPT}'),
+			('a[^', f'^(?:(?s:.)+/)?a\\[\\^{_DIR_OPT}'),
+			('a[a-', f'^(?:(?s:.)+/)?a\\[a\\-{_DIR_OPT}'),
+			('a[a-z', f'^(?:(?s:.)+/)?a\\[a\\-z{_DIR_OPT}'),
 		]:
 			with self.subTest(f"p={raw_pattern!r}"):
 				pattern = GitIgnoreBasicPattern(raw_pattern)
@@ -982,3 +982,14 @@ class GitIgnoreBasicPatternTest(unittest.TestCase):
 		pattern = GitIgnoreBasicPattern('*.py')
 		self.assertEqual(repr(pattern), "GitIgnoreBasicPattern(pattern='*.py', include=True)")
 		self.assertEqual(str(pattern), '*.py')
+
+	def test_globstars_match_newlines(self):
+		for pattern, path in [
+			("target", "line\nbreak/target"),
+			("**/target", "line\nbreak/target"),
+			("root/**/target", "root/line\nbreak/target"),
+			("**", "\n"),
+			("*", "\n"),
+		]:
+			with self.subTest(pattern=pattern, path=path):
+				self.assertIsNotNone(GitIgnoreBasicPattern(pattern).match_file(path))

--- a/tests/test_04_gitignore_spec.py
+++ b/tests/test_04_gitignore_spec.py
@@ -137,7 +137,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('spam')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?spam{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?spam{_DIR_MARK_OPT}')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -201,7 +201,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('!temp')
 		self.assertIs(include, False)
-		self.assertEqual(regex, f'^(?:.+/)?temp{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?temp{_DIR_MARK_OPT}')
 
 		# NOTE: The pattern match is backwards because the pattern itself
 		# does not consider the include attribute.
@@ -254,7 +254,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('left/**/right')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^left(?:/.+)?/right{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^left(?:/(?s:.)+)?/right{_DIR_MARK_OPT}')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -314,7 +314,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/spam')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?spam{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?spam{_DIR_MARK_OPT}')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -346,7 +346,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/api')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?api{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?api{_DIR_MARK_OPT}')
 
 		equiv_regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/**/api')
 		self.assertTrue(include)
@@ -354,7 +354,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/api/')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?api{_DIR_MARK_CG}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?api{_DIR_MARK_CG}')
 
 		equiv_regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/**/api/')
 		self.assertTrue(include)
@@ -362,7 +362,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/api/**')
 		self.assertTrue(include)
-		self.assertEqual(regex, '^(?:.+/)?api/')
+		self.assertEqual(regex, '^(?:(?s:.)+/)?api/')
 
 		equiv_regex, include = GitIgnoreSpecPattern.pattern_to_regex('**/**/api/**/**')
 		self.assertTrue(include)
@@ -396,7 +396,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('foo-*-bar')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?foo\\-[^/]*\\-bar{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?foo\\-[^/]*\\-bar{_DIR_MARK_OPT}')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -428,7 +428,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('~temp-*')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?\\~temp\\-[^/]*{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?\\~temp\\-[^/]*{_DIR_MARK_OPT}')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -459,7 +459,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('*.py')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?[^/]*\\.py{_DIR_MARK_OPT}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?[^/]*\\.py{_DIR_MARK_OPT}')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -491,7 +491,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		regex, include = GitIgnoreSpecPattern.pattern_to_regex('dir/')
 		self.assertTrue(include)
-		self.assertEqual(regex, f'^(?:.+/)?dir{_DIR_MARK_CG}')
+		self.assertEqual(regex, f'^(?:(?s:.)+/)?dir{_DIR_MARK_CG}')
 
 		pattern = GitIgnoreSpecPattern(re.compile(regex), include)
 		results = set(filter(pattern.match_file, [
@@ -897,7 +897,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		# GitIgnoreSpecPattern will match the file, but GitIgnoreSpec should not.
 		pattern = GitIgnoreSpecPattern('!libfoo/')
 
-		self.assertEqual(pattern.regex.pattern, f'^(?:.+/)?libfoo{_DIR_MARK_CG}')
+		self.assertEqual(pattern.regex.pattern, f'^(?:(?s:.)+/)?libfoo{_DIR_MARK_CG}')
 		self.assertIs(pattern.include, False)
 		self.assertTrue(pattern.match_file('libfoo/__init__.py'))
 
@@ -907,7 +907,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreSpecPattern('foo**')
 		self.assertIs(pattern.include, True)
-		self.assertEqual(pattern.regex.pattern, f'^(?:.+/)?foo[^/]*[^/]*{_DIR_MARK_OPT}')
+		self.assertEqual(pattern.regex.pattern, f'^(?:(?s:.)+/)?foo[^/]*[^/]*{_DIR_MARK_OPT}')
 		self.assertTrue(pattern.match_file('foosrodah'))
 
 	def test_15_issue_93_a_2(self):
@@ -926,7 +926,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreSpecPattern(' foo')
 		self.assertIs(pattern.include, True)
-		self.assertEqual(pattern.regex.pattern, f'^(?:.+/)?\\ foo{_DIR_MARK_OPT}')
+		self.assertEqual(pattern.regex.pattern, f'^(?:(?s:.)+/)?\\ foo{_DIR_MARK_OPT}')
 		self.assertFalse(pattern.match_file('foo'))
 		self.assertTrue(pattern.match_file(' foo'))
 
@@ -936,7 +936,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		"""
 		pattern = GitIgnoreSpecPattern('  foo')
 		self.assertIs(pattern.include, True)
-		self.assertEqual(pattern.regex.pattern, f'^(?:.+/)?\\ \\ foo{_DIR_MARK_OPT}')
+		self.assertEqual(pattern.regex.pattern, f'^(?:(?s:.)+/)?\\ \\ foo{_DIR_MARK_OPT}')
 		self.assertFalse(pattern.match_file('foo'))
 		self.assertFalse(pattern.match_file(' foo'))
 		self.assertTrue(pattern.match_file('  foo'))
@@ -946,12 +946,12 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 		Test patterns with valid range notation.
 		"""
 		for raw_pattern, regex in [
-			('[!a-z]', f'^(?:.+/)?[^a-z]{_DIR_MARK_OPT}'),
-			('[^a-z]', f'^(?:.+/)?[^a-z]{_DIR_MARK_OPT}'),
-			('[a-z]', f'^(?:.+/)?[a-z]{_DIR_MARK_OPT}'),
-			('a[!a-z]', f'^(?:.+/)?a[^a-z]{_DIR_MARK_OPT}'),
-			('a[^a-z]', f'^(?:.+/)?a[^a-z]{_DIR_MARK_OPT}'),
-			('a[a-z]', f'^(?:.+/)?a[a-z]{_DIR_MARK_OPT}'),
+			('[!a-z]', f'^(?:(?s:.)+/)?[^a-z]{_DIR_MARK_OPT}'),
+			('[^a-z]', f'^(?:(?s:.)+/)?[^a-z]{_DIR_MARK_OPT}'),
+			('[a-z]', f'^(?:(?s:.)+/)?[a-z]{_DIR_MARK_OPT}'),
+			('a[!a-z]', f'^(?:(?s:.)+/)?a[^a-z]{_DIR_MARK_OPT}'),
+			('a[^a-z]', f'^(?:(?s:.)+/)?a[^a-z]{_DIR_MARK_OPT}'),
+			('a[a-z]', f'^(?:(?s:.)+/)?a[a-z]{_DIR_MARK_OPT}'),
 		]:
 			with self.subTest(f"p={raw_pattern!r}"):
 				pattern = GitIgnoreSpecPattern(raw_pattern)
@@ -1025,7 +1025,7 @@ class GitIgnoreSpecPatternTest(unittest.TestCase):
 				pattern = GitIgnoreSpecPattern(raw_pattern)
 				self.assertIs(pattern.include, True)
 				self.assertEqual(
-					pattern.regex.pattern, f'^(?:.+/)?{expr}{_DIR_MARK_OPT}',
+					pattern.regex.pattern, f'^(?:(?s:.)+/)?{expr}{_DIR_MARK_OPT}',
 				)
 
 	def test_16_posix_class_b_match(self):

--- a/tests/test_06_gitignore.py
+++ b/tests/test_06_gitignore.py
@@ -907,3 +907,14 @@ class GitIgnoreSpecTest(unittest.TestCase):
 					"node_modules/",
 					"node_modules/leaf.txt",
 				}, debug)
+
+	def test_globstars_match_newlines_in_directory_names(self):
+		for pattern, path in [
+			("target", "line\nbreak/target"),
+			("**/target", "line\nbreak/target"),
+			("root/**/target", "root/line\nbreak/target"),
+			("**/target", "\n/target"),
+		]:
+			for sub_test in self.parameterize_from_lines([pattern]):
+				with self.subTest(pattern=pattern, path=path), sub_test() as spec:
+					self.assertTrue(spec.match_file(path))


### PR DESCRIPTION
Patterns such as `target`, `**/target`, and `root/**/target` fail to match when a parent directory contains a newline: the generated globstar regex uses a dot without DOTALL. `GitIgnoreBasicPattern` also misses a filename consisting only of a newline for `*` and `**`.

Use scoped DOTALL for globstar segments and the basic match-all shortcut. Update literal regex expectations, add newline regressions, and include a changelog entry. Matching ordinary segment characters remains unchanged.

Validation: new regressions fail before the change; 214 tests and 652 subtests pass with simple, RE2, and Hyperscan backends on CPython 3.12.14. Five cases were independently checked against `git check-ignore --stdin -z` in real temporary repositories; Git and all three backends agree.

Implemented and locally validated with OpenAI Codex.

Issue tracking: Found during source inspection; no matching open issue was identified for this fix.
