### PR TITLE
Update publishing action for metadata 2.5 support

### DIFF
--- a/.github/workflows/publish-to-pypi.yaml
+++ b/.github/workflows/publish-to-pypi.yaml
@@ -58,6 +58,6 @@ jobs:
           path: dist/
 
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0 from 2026-04-07.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2 from 2026-07-29.
         with:
           print-hash: true

--- a/.github/workflows/publish-to-testpypi.yaml
+++ b/.github/workflows/publish-to-testpypi.yaml
@@ -67,7 +67,7 @@ jobs:
           path: dist/
 
       - name: Publish distribution to TestPyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0 from 2026-04-07.
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2 from 2026-07-29.
         with:
           repository-url: https://test.pypi.org/legacy/
           print-hash: true


### PR DESCRIPTION
The TestPyPI publish run rejects both distributions with `InvalidDistribution: Invalid distribution metadata: unrecognized or malformed field 'import-name'`. The uploaded wheel and sdist use metadata 2.5, but the pinned v1.14.0 publisher uses Twine 6.1.0 and packaging 25.0.

Update the publisher pin in both release workflows to v1.14.2, which includes metadata 2.5 support. The workflow triggers, permissions, environments and publish inputs are unchanged. The regular PyPI workflow uses the same old pin, so it gets the same preventive update.

Validation used the original wheel and sdist from [the failed run](https://github.com/cpburnz/python-pathspec/actions/runs/33972689218), after checking the downloaded artifact digest. Both files fail strict checks with the old publisher and pass with the new publisher on macOS and in the official Linux publisher images. The Linux checks ran offline with read-only inputs. A parsed YAML comparison confirms that only the two publisher references changed. No upload, OIDC exchange or attestation generation was performed.
